### PR TITLE
added missing dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,11 @@ try:
     'gdata',
     'pdfminer == 20110515',#Note that API has changed dramatically in later versions
     'docx', #good for text, bad for metadata
-    'openxmlinfo', #good for metadata, bad for text
+    'openxmllib', #good for metadata, bad for text
     'pytesseract',
+    'argcomplete',
+    'pyOpenSSL',  # required, in practice, by oauth2client
+    'boto'
     ]
 
     try:


### PR DESCRIPTION
When trying to follow the install instructions in README.md (using a fresh virtualenv), it turned out that some required packages were missing from install_requires in setup.py.

With these changes, I can run harvest.py and have it connecting to Google spreadsheets, Amazon S3 and starting Firefox.
